### PR TITLE
Activating unittest for plugin test and docker image

### DIFF
--- a/.github/workflows/batoms_plugin_test.yaml
+++ b/.github/workflows/batoms_plugin_test.yaml
@@ -3,9 +3,13 @@ name: Test batoms blender plugin
 
 on:
   push:
-    branches: [master]
+    branches: 
+      - main
+      - develop
   pull_request:
-    branches: [master]
+    branches: 
+      - main
+      - develop
   workflow_dispatch:
 
 jobs:
@@ -50,29 +54,3 @@ jobs:
         run: |
           cd test
           PYTHONPATH=$(pwd) bash test_ci.sh
-
-
-    # - name: Get Tag
-    #   uses: olegtarasov/get-tag@v2
-    #   id: tagName
-    #   with:
-    #       tagRegex: "foobar-(.*)"  # Optional. Returns specified group text as tag name. Full tag string is returned if regex is not defined.
-    #       tagRegexGroup: 1 # Optional. Default is 1.
-    # - name: Set Tag # Output usage example
-    #   run: |
-    #       echo "${{ steps.tagName.outputs.tag }}"
-    #       tag="${{ steps.tagName.outputs.tag }}"
-    #       echo "GIT_TAG=$tag" >> $GITHUB_ENV
-    #   shell: bash
-    # - name: Test tag
-    #   run: |
-    #     echo "${{ env.GIT_TAG }}"
-    #   shell: bash
-    # - name: Test encoding
-    #   run: |
-    #     python -c "import sys; print(sys.getdefaultencoding())"
-    # - name: Testing examples
-    #   run: |
-    #     make examples
-    #     pytest examples
-    #   shell: bash

--- a/.github/workflows/batoms_plugin_test.yaml
+++ b/.github/workflows/batoms_plugin_test.yaml
@@ -28,7 +28,7 @@ jobs:
         cp -r batoms $BLENDER_PATH/scripts/addons_contrib/
     - name: Enable blender addons
       run: |
-        blender -b --python-exit-code 1 --python-expr  "import addon_utils; addon_utils.enable('batoms', default_set=True); bpy.ops.wm.save_userpref(); print('success')"
+        blender -b --python-exit-code 1 --python-expr  "import bpy; import addon_utils; addon_utils.enable('batoms', default_set=True); bpy.ops.wm.save_userpref(); print('success')"
     - name: Test blender path
       run: |
         blender -b --python-exit-code 1 --python-expr "import sys; print(sys.path)"

--- a/.github/workflows/batoms_plugin_test.yaml
+++ b/.github/workflows/batoms_plugin_test.yaml
@@ -3,9 +3,9 @@ name: Test batoms blender plugin
 
 on:
   push:
-    branches: [ master ]
+    branches: [master]
   pull_request:
-    branches: [ master ]
+    branches: [master]
   workflow_dispatch:
 
 jobs:
@@ -21,30 +21,37 @@ jobs:
       options: --user root
 
     steps:
-    - uses: actions/checkout@v2
-    - name: Copy addons to blender
-      run: |
-        mkdir -p $BLENDER_PATH/scripts/addons_contrib
-        cp -r batoms $BLENDER_PATH/scripts/addons_contrib/
-    - name: Enable blender addons
-      run: |
-        blender -b --python-exit-code 1 --python-expr  "import bpy; import addon_utils; addon_utils.enable('batoms', default_set=True); bpy.ops.wm.save_userpref(); print('success')"
-    - name: Test blender path
-      run: |
-        blender -b --python-exit-code 1 --python-expr "import sys; print(sys.path)"
-    - name: Test import
-      run: |
-        blender -b --python-exit-code 1 --python-expr  "from batoms import Batoms; b = Batoms('O', ['O'], [[0, 0, 0]])"
-    - name: Install test dependencies
-      run: |
-        $BLENDERPY -m pip install pytest flake8
-    - name: Lint with flake8
-      run: |
-        # stop the build if there are Python syntax errors or undefined names
-        flake8 . --exclude=batoms/gui/,batoms/modal,batoms/__init__.py,batoms/custom_property.py --count --select=E9,F63,F7,F82 --show-source --statistics
-        # exit-zero treats all errors as warnings. The GitHub editor is 127 chars wide
-        flake8 . --exclude=batoms/gui/,batoms/modal,batoms/__init__.py,batoms/custom_property.py --count --exit-zero --max-complexity=10 --max-line-length=127 --statistics
-    
+      - uses: actions/checkout@v2
+      - name: Copy addons to blender
+        run: |
+          mkdir -p $BLENDER_PATH/scripts/addons_contrib
+          cp -r batoms $BLENDER_PATH/scripts/addons_contrib/
+      - name: Enable blender addons
+        # Enable the blender blender addon and save user pref
+        run: |
+          blender -b --python-exit-code 1 --python-expr  "import bpy; import addon_utils; addon_utils.enable('batoms', default_set=True); bpy.ops.wm.save_userpref(); print('success')"
+      - name: Test blender path
+        # Test the sys.path contains the `addons_contrib` path
+        run: |
+          blender -b --python-exit-code 1 --python-expr "import sys; assert(any(['scripts/addons_contrib' in p for p in sys.path]))"
+      - name: Test import
+        run: |
+          blender -b --python-exit-code 1 --python-expr  "from batoms import Batoms; b = Batoms('O', ['O'], [[0, 0, 0]])"
+      - name: Install test dependencies
+        run: |
+          $BLENDERPY -m pip install pytest flake8
+      - name: Lint with flake8
+        run: |
+          # stop the build if there are Python syntax errors or undefined names
+          flake8 . --exclude=batoms/gui/,batoms/modal,batoms/__init__.py,batoms/custom_property.py --count --select=E9,F63,F7,F82 --show-source --statistics
+          # exit-zero treats all errors as warnings. The GitHub editor is 127 chars wide
+          flake8 . --exclude=batoms/gui/,batoms/modal,batoms/__init__.py,batoms/custom_property.py --count --exit-zero --max-complexity=10 --max-line-length=127 --statistics
+      - name: Run blender unittests
+        run: |
+          cd test
+          source test.sh
+
+
     # - name: Get Tag
     #   uses: olegtarasov/get-tag@v2
     #   id: tagName

--- a/.github/workflows/batoms_plugin_test.yaml
+++ b/.github/workflows/batoms_plugin_test.yaml
@@ -29,6 +29,9 @@ jobs:
     - name: Enable blender addons
       run: |
         blender -b --python-exit-code 1 --python-expr  "import addon_utils; addon_utils.enable('batoms', default_set=True); bpy.ops.wm.save_userpref(); print('success')"
+    - name: Test blender path
+      run: |
+        blender -b --python-exit-code 1 --python-expr "import sys; print(sys.path)"
     - name: Test import
       run: |
         blender -b --python-exit-code 1 --python-expr  "from batoms import Batoms; b = Batoms('O', ['O'], [[0, 0, 0]])"

--- a/.github/workflows/batoms_plugin_test.yaml
+++ b/.github/workflows/batoms_plugin_test.yaml
@@ -49,7 +49,7 @@ jobs:
       - name: Run blender unittests
         run: |
           cd test
-          source test.sh
+          PYTHONPATH=$(pwd) bash test_ci.sh
 
 
     # - name: Get Tag

--- a/.github/workflows/build_blender_env_image.yml
+++ b/.github/workflows/build_blender_env_image.yml
@@ -6,8 +6,8 @@ env:
 on:
   push:
     paths:
-      - 'Dockerfiles/Dockerfile.base_*'
-      - '.github/workflows/build_blend_env_image.yml'
+      - "Dockerfiles/Dockerfile.base_*"
+      - ".github/workflows/build_blend_env_image.yml"
   workflow_dispatch:
 
 jobs:

--- a/.github/workflows/build_main_image.yml
+++ b/.github/workflows/build_main_image.yml
@@ -5,9 +5,9 @@ env:
 
 on:
   push:
-    branches: [ master ]
+    branches: [master]
   pull_request:
-    branches: [ master ]
+    branches: [master]
   workflow_dispatch:
 
 jobs:

--- a/.github/workflows/build_main_image.yml
+++ b/.github/workflows/build_main_image.yml
@@ -6,11 +6,11 @@ env:
 
 on:
   push:
-    branches: 
+    branches:
       - main
       - develop
   pull_request:
-    branches: 
+    branches:
       - main
       - develop
   workflow_dispatch:
@@ -50,10 +50,21 @@ jobs:
           # push: true
           # tags: ${{ secrets.DOCKERHUB_USERNAME }}/${{ env.image_name }}:blender${{ matrix.blender-version }}
           tags: ${{ env.TEST_TAG }}
-          cache-from: type=registry,ref=${{ secrets.DOCKERHUB_USERNAME }}/${{ env.image_name }}:buildcache
-          cache-to: type=registry,ref=${{ secrets.DOCKERHUB_USERNAME }}/${{ env.image_name }}:buildcache,mode=max
-#           cache-from: type=registry,ref=${{ secrets.DOCKERHUB_USERNAME }}/${{ env.image_name }}:${{ matrix.blender-version }}
-#           cache-to: type=inline
+          # cache-from: type=registry,ref=${{ secrets.DOCKERHUB_USERNAME }}/${{ env.image_name }}:buildcache
+          # cache-to: type=registry,ref=${{ secrets.DOCKERHUB_USERNAME }}/${{ env.image_name }}:buildcache,mode=max
+      #           cache-from: type=registry,ref=${{ secrets.DOCKERHUB_USERNAME }}/${{ env.image_name }}:${{ matrix.blender-version }}
+      #           cache-to: type=inline
       - name: Test local image
         run: |
           docker run --rm -v $(pwd)/test:/workdir -e CI=1 ${{ env.TEST_TAG }} bash test_ci.sh
+
+      - name: Push image
+        uses: docker/build-push-action@v2
+        with:
+          context: ./
+          file: ./Dockerfiles/Dockerfile.main
+          build-args: BLENDER_VER=${{ matrix.blender-version }}
+          push: true
+          tags: ${{ secrets.DOCKERHUB_USERNAME }}/${{ env.image_name }}:blender${{ matrix.blender-version }}
+          cache-from: type=registry,ref=${{ secrets.DOCKERHUB_USERNAME }}/${{ env.image_name }}:buildcache
+          cache-to: type=registry,ref=${{ secrets.DOCKERHUB_USERNAME }}/${{ env.image_name }}:buildcache,mode=max

--- a/.github/workflows/build_main_image.yml
+++ b/.github/workflows/build_main_image.yml
@@ -56,4 +56,4 @@ jobs:
 #           cache-to: type=inline
       - name: Test local image
         run: |
-          docker run --rm -it -v $(pwd)/test:/workdir -e CI=1 ${{ env.TEST_TAG }} bash test_ci.sh
+          docker run --rm -v $(pwd)/test:/workdir -e CI=1 ${{ env.TEST_TAG }} bash test_ci.sh

--- a/.github/workflows/build_main_image.yml
+++ b/.github/workflows/build_main_image.yml
@@ -2,6 +2,7 @@ name: Build beautiful_atoms main image
 
 env:
   image_name: beautiful_atoms
+  TEST_TAG: beautiful_atoms:test
 
 on:
   push:
@@ -39,15 +40,20 @@ jobs:
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
-      - name: Build and push
+      - name: Build local copy
         uses: docker/build-push-action@v2
         with:
           context: ./
           file: ./Dockerfiles/Dockerfile.main
           build-args: BLENDER_VER=${{ matrix.blender-version }}
-          push: true
-          tags: ${{ secrets.DOCKERHUB_USERNAME }}/${{ env.image_name }}:blender${{ matrix.blender-version }}
+          load: true
+          # push: true
+          # tags: ${{ secrets.DOCKERHUB_USERNAME }}/${{ env.image_name }}:blender${{ matrix.blender-version }}
+          tags: ${{ env.TEST_TAG }}
           cache-from: type=registry,ref=${{ secrets.DOCKERHUB_USERNAME }}/${{ env.image_name }}:buildcache
           cache-to: type=registry,ref=${{ secrets.DOCKERHUB_USERNAME }}/${{ env.image_name }}:buildcache,mode=max
 #           cache-from: type=registry,ref=${{ secrets.DOCKERHUB_USERNAME }}/${{ env.image_name }}:${{ matrix.blender-version }}
 #           cache-to: type=inline
+      - name: Test local image
+        run: |
+          docker run --rm -it -v $(pwd)/test:/workdir -e CI=1 ${{ env.TEST_TAG }} bash test_ci.sh

--- a/.github/workflows/build_main_image.yml
+++ b/.github/workflows/build_main_image.yml
@@ -65,6 +65,8 @@ jobs:
           file: ./Dockerfiles/Dockerfile.main
           build-args: BLENDER_VER=${{ matrix.blender-version }}
           push: true
-          tags: ${{ secrets.DOCKERHUB_USERNAME }}/${{ env.image_name }}:blender${{ matrix.blender-version }}
+          tags: |
+            ${{ secrets.DOCKERHUB_USERNAME }}/${{ env.image_name }}:blender${{ matrix.blender-version }}
+            ${{ secrets.DOCKERHUB_USERNAME }}/${{ env.image_name }}:latest
           cache-from: type=registry,ref=${{ secrets.DOCKERHUB_USERNAME }}/${{ env.image_name }}:buildcache
           cache-to: type=registry,ref=${{ secrets.DOCKERHUB_USERNAME }}/${{ env.image_name }}:buildcache,mode=max

--- a/.github/workflows/build_main_image.yml
+++ b/.github/workflows/build_main_image.yml
@@ -5,9 +5,13 @@ env:
 
 on:
   push:
-    branches: [master]
+    branches: 
+      - main
+      - develop
   pull_request:
-    branches: [master]
+    branches: 
+      - main
+      - develop
   workflow_dispatch:
 
 jobs:

--- a/Dockerfiles/Dockerfile.main
+++ b/Dockerfiles/Dockerfile.main
@@ -14,11 +14,11 @@ COPY batoms ${BLENDER_PATH}/scripts/addons_contrib/batoms
 RUN blender -b \
             --python-exit-code 1 \
             --python-expr  \
-            "import addon_utils; addon_utils.enable('batoms', default_set=True); print('success')" &&\
+            "import bpy; import addon_utils; addon_utils.enable('batoms', default_set=True); bpy.ops.wm.save_userpref(); print('success')" &&\
     blender -b \
             --python-exit-code 1 \
             --python-expr  \
-            "from batoms import Batoms; print('success')"
+            "from batoms import Batoms; b = Batoms('O', ['O'], [[0, 0, 0]]); print('success')"
 
  
 RUN chmod 744 -R ${BLENDER_PATH}/scripts/addons_contrib/batoms

--- a/README.md
+++ b/README.md
@@ -1,4 +1,5 @@
 ### Beautiful Atoms
+[![Build beautiful_atoms main image](https://github.com/alchem0x2A/beautiful-atoms/actions/workflows/build_main_image.yml/badge.svg)](https://github.com/alchem0x2A/beautiful-atoms/actions/workflows/build_main_image.yml)
 [![Test batoms blender plugin](https://github.com/alchem0x2A/beautiful-atoms/actions/workflows/batoms_plugin_test.yaml/badge.svg)](https://github.com/alchem0x2A/beautiful-atoms/actions/workflows/batoms_plugin_test.yaml)
 
 Batoms is a Python package for editing and rendering atoms and molecules objects using blender. A Python interface that allows for automating workflows.

--- a/README.md
+++ b/README.md
@@ -1,4 +1,5 @@
 ### Beautiful Atoms
+[![Test batoms blender plugin](https://github.com/alchem0x2A/beautiful-atoms/actions/workflows/batoms_plugin_test.yaml/badge.svg)](https://github.com/alchem0x2A/beautiful-atoms/actions/workflows/batoms_plugin_test.yaml)
 
 Batoms is a Python package for editing and rendering atoms and molecules objects using blender. A Python interface that allows for automating workflows.
 

--- a/test/_common_helpers.py
+++ b/test/_common_helpers.py
@@ -1,0 +1,20 @@
+"""This module is only to be used together with tests
+"""
+import os
+
+
+def has_display():
+    """Detect display, should work in linux systems; windows not tested"""
+    display_string = os.environ.get("DISPLAY", "")
+    return len(display_string) > 0
+
+
+# Very bad resolution only for cycles output
+CYCLES_TEST_RES = [20, 20]
+
+
+def set_cycles_res(obj, res=CYCLES_TEST_RES):
+    """Set the cycles render resolution, default to 20x20"""
+    assert hasattr(obj, "render")
+    obj.render.resolution = res
+    return

--- a/test/test.sh
+++ b/test/test.sh
@@ -1,4 +1,5 @@
-rm *png
+#!/bin/bash
+rm -rf *png
 blender -b -P test_animation.py
 blender -b -P test_batom.py
 blender -b -P test_batoms.py

--- a/test/test_animation.py
+++ b/test/test_animation.py
@@ -5,20 +5,20 @@ from batoms.utils.butils import removeAll
 
 def test_animation_molecule():
     removeAll()
-    deca = read('datas/deca_ala_md.xyz', index=':')
-    deca = Batoms('deca', from_ase=deca, movie=True)
+    deca = read("datas/deca_ala_md.xyz", index=":")
+    deca = Batoms("deca", from_ase=deca, movie=True)
     deca.model_style = 1
 
 
 def test_animation_crystal():
     removeAll()
-    atoms = read('datas/tio2_10.xyz', index=':')
-    tio2 = Batoms('tio2', from_ase=atoms, movie=True)
+    atoms = read("datas/tio2_10.xyz", index=":")
+    tio2 = Batoms("tio2", from_ase=atoms, movie=True)
     tio2.model_style = 2
     tio2.boundary = 0.01
 
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     test_animation_molecule()
     test_animation_crystal()
-    print('\n Animation: All pass! \n')
+    print("\n Animation: All pass! \n")

--- a/test/test_batom.py
+++ b/test/test_batom.py
@@ -6,20 +6,18 @@ import numpy as np
 
 
 def test_batoms_batom():
-    """Setting individual Batom
-    """
+    """Setting individual Batom"""
     removeAll()
-    h2o = Batoms('h2o', from_ase=molecule('H2O'))
+    h2o = Batoms("h2o", from_ase=molecule("H2O"))
     print(h2o[0])
     h2o[1].scale = 1
     h2o[1].show = 0
     h2o[1].show = 1
-    h2o[1].species = 'Cl'
-    assert np.isclose(h2o[1].position,
-                      np.array([0., 0.76323903, -0.477047])).all()
-    assert h2o[1].species == 'Cl'
+    h2o[1].species = "Cl"
+    assert np.isclose(h2o[1].position, np.array([0.0, 0.76323903, -0.477047])).all()
+    assert h2o[1].species == "Cl"
 
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     test_batoms_batom()
-    print('\n Batom: All pass! \n')
+    print("\n Batom: All pass! \n")

--- a/test/test_batoms.py
+++ b/test/test_batoms.py
@@ -6,67 +6,63 @@ import pytest
 
 
 def test_empty():
-    """Create an empty Batoms object
-    """
+    """Create an empty Batoms object"""
     removeAll()
-    h2o = Batoms('h2o')
+    h2o = Batoms("h2o")
     assert len(h2o) == 0
 
 
 def test_batoms_molecule():
-    """Create a Batoms object from scratch
-    """
+    """Create a Batoms object from scratch"""
     removeAll()
-    h2o = Batoms('h2o', species=['O', 'H', 'H'],
-                 positions=[[0, 0, 0.40],
-                            [0, -0.76, -0.2],
-                            [0, 0.76, -0.2]])
+    h2o = Batoms(
+        "h2o",
+        species=["O", "H", "H"],
+        positions=[[0, 0, 0.40], [0, -0.76, -0.2], [0, 0.76, -0.2]],
+    )
     assert len(h2o) == 3
 
 
 def test_batoms_crystal():
-    """Create a Batoms object with cell
-    """
+    """Create a Batoms object with cell"""
     removeAll()
     a = 4.08
-    positions = [[0, 0, 0],
-                 [a/2, a/2, 0],
-                 [a/2, 0, a/2],
-                 [0, a/2, a/2]]
-    au = Batoms(label='au',
-                species=['Au']*len(positions),
-                positions=positions,
-                pbc=True,
-                cell=(a, a, a))
+    positions = [[0, 0, 0], [a / 2, a / 2, 0], [a / 2, 0, a / 2], [0, a / 2, a / 2]]
+    au = Batoms(
+        label="au",
+        species=["Au"] * len(positions),
+        positions=positions,
+        pbc=True,
+        cell=(a, a, a),
+    )
     assert au.pbc == [True, True, True]
     assert np.isclose(au.cell[0, 0], a)
 
 
 def test_batoms_species():
-    """Setting properties of species
-    """
+    """Setting properties of species"""
     removeAll()
-    h2o = Batoms('h2o', species=['O', 'H', 'H'],
-                 positions=[[0, 0, 0.40],
-                            [0, -0.76, -0.2],
-                            [0, 0.76, -0.2]])
+    h2o = Batoms(
+        "h2o",
+        species=["O", "H", "H"],
+        positions=[[0, 0, 0.40], [0, -0.76, -0.2], [0, 0.76, -0.2]],
+    )
     assert len(h2o.species) == 2
     # default covalent radius
-    assert np.isclose(h2o.radius['H'], 0.31)
+    assert np.isclose(h2o.radius["H"], 0.31)
     # vdw radius
-    h2o.species['H'].radius_style = 1
-    assert np.isclose(h2o.radius['H'], 1.2)
+    h2o.species["H"].radius_style = 1
+    assert np.isclose(h2o.radius["H"], 1.2)
     # default Jmol color
-    assert np.isclose(h2o['H'].color, np.array([1, 1, 1, 1])).all()
+    assert np.isclose(h2o["H"].color, np.array([1, 1, 1, 1])).all()
     # VESTA color
-    h2o.species['H'].color_style = 2
-    assert np.isclose(h2o['H'].color, np.array([1, 0.8, 0.8, 1])).all()
+    h2o.species["H"].color_style = 2
+    assert np.isclose(h2o["H"].color, np.array([1, 0.8, 0.8, 1])).all()
     # materials
-    h2o.species['H'].materials = {
-        'Metallic': 0.9, 'Specular': 1.0, 'Roughness': 0.01}
+    h2o.species["H"].materials = {"Metallic": 0.9, "Specular": 1.0, "Roughness": 0.01}
     # elements
-    h2o.species['H'].elements = {'H': 0.5, 'O': 0.4}
-    assert len(h2o['H'].elements) == 3
+    h2o.species["H"].elements = {"H": 0.5, "O": 0.4}
+    assert len(h2o["H"].elements) == 3
 
 
 def test_batoms_write(filename):
@@ -76,43 +72,42 @@ def test_batoms_write(filename):
         filename (str): filename and format of output file
     """
     removeAll()
-    h2o = Batoms('h2o', species=['O', 'H', 'H'],
-                 positions=[[0, 0, 0.40],
-                            [0, -0.76, -0.2],
-                            [0, 0.76, -0.2]])
-    h2o.write('h2o.in')
+    h2o = Batoms(
+        "h2o",
+        species=["O", "H", "H"],
+        positions=[[0, 0, 0.40], [0, -0.76, -0.2], [0, 0.76, -0.2]],
+    )
+    h2o.write("h2o.in")
 
 
 def test_batoms_transform():
-    """Transform: translate, rotate, mirror
-    """
+    """Transform: translate, rotate, mirror"""
     removeAll()
-    h2o = Batoms('h2o', species=['O', 'H', 'H'],
-                 positions=[[0, 0, 0.40],
-                            [0, -0.76, -0.2],
-                            [0, 0.76, -0.2]])
+    h2o = Batoms(
+        "h2o",
+        species=["O", "H", "H"],
+        positions=[[0, 0, 0.40], [0, -0.76, -0.2], [0, 0.76, -0.2]],
+    )
     h2o.translate([0, 0, 2])
     assert np.isclose(h2o.positions[0], np.array([0, 0, 2.40])).all()
-    h2o.mirror('Z')
+    h2o.mirror("Z")
     assert np.isclose(h2o.positions[0], np.array([0, 0, 1.6])).all()
     # h2o.rotate(90, 'Z')
     # assert np.isclose(h2o.positions[0], np.array([0.76, 0, -2.2])).all()
 
 
 def test_batoms_wrap():
-    """Wrap atoms into pbc cell
-    """
+    """Wrap atoms into pbc cell"""
     removeAll()
     a = 4.08
-    positions = [[0, 0, 0],
-                 [a/2, a/2, 0],
-                 [a/2, 0, a/2],
-                 [0, a/2, a/2]]
-    au = Batoms(label='au',
-                species=['Au']*len(positions),
-                positions=positions,
-                pbc=True,
-                cell=(a, a, a))
+    positions = [[0, 0, 0], [a / 2, a / 2, 0], [a / 2, 0, a / 2], [0, a / 2, a / 2]]
+    au = Batoms(
+        label="au",
+        species=["Au"] * len(positions),
+        positions=positions,
+        pbc=True,
+        cell=(a, a, a),
+    )
     assert np.isclose(au[0].position, np.array([0, 0, 0])).all()
     au[0].position = np.array([-0.3, 0, 0])
     # evaluated
@@ -120,98 +115,90 @@ def test_batoms_wrap():
 
 
 def test_batoms_supercell():
-    """make supercell
-    """
+    """make supercell"""
     removeAll()
-    au = Batoms('au', from_ase=bulk('Au'))
-    P = np.array([[2, 3, 0, 5],
-                  [0, 1, 0, 5],
-                  [0, 0, 1, 0],
-                  [0, 0, 0, 1]])
+    au = Batoms("au", from_ase=bulk("Au"))
+    P = np.array([[2, 3, 0, 5], [0, 1, 0, 5], [0, 0, 1, 0], [0, 0, 0, 1]])
     au = au.transform(P)
     # assert au.cell
     assert len(au) == 2
 
 
 def test_batoms_occupy():
-    """setting occupancy
-    """
+    """setting occupancy"""
     removeAll()
-    h2o = Batoms('h2o', species=['O', 'H', 'H'],
-                 species_props={'O': {'elements': {'O': 0.8, 'N': 0.2}},
-                                'H': {'elements': {'H': 0.8}}},
-                 positions=[[0, 0, 0.40],
-                            [0, -0.76, -0.2],
-                            [0, 0.76, -0.2]])
-    h2o.species['O'] = {'elements': {'O': 0.3, 'Cl': 0.3}}
+    h2o = Batoms(
+        "h2o",
+        species=["O", "H", "H"],
+        species_props={
+            "O": {"elements": {"O": 0.8, "N": 0.2}},
+            "H": {"elements": {"H": 0.8}},
+        },
+        positions=[[0, 0, 0.40], [0, -0.76, -0.2], [0, 0.76, -0.2]],
+    )
+    h2o.species["O"] = {"elements": {"O": 0.3, "Cl": 0.3}}
 
 
 def test_batoms_copy():
-    """copy batoms
-    """
+    """copy batoms"""
     removeAll()
-    h2o = Batoms('h2o', from_ase=molecule('H2O'))
+    h2o = Batoms("h2o", from_ase=molecule("H2O"))
     h2o.pbc = True
     h2o.cell = [3, 3, 3]
-    h2o_2 = h2o.copy('h2o_2')
+    h2o_2 = h2o.copy("h2o_2")
     assert isinstance(h2o_2, Batoms)
     assert len(h2o_2) == 3
 
 
 def test_replace():
-    """replace
-    """
+    """replace"""
     removeAll()
-    h2o = Batoms('h2o', from_ase=molecule('H2O'))
-    h2o.replace([1], 'C')
+    h2o = Batoms("h2o", from_ase=molecule("H2O"))
+    h2o.replace([1], "C")
     assert len(h2o.species) == 3
-    assert h2o[1].species == 'C'
+    assert h2o[1].species == "C"
 
 
 def test_batoms_add():
-    """Merge two Batoms objects
-    """
+    """Merge two Batoms objects"""
     removeAll()
-    h2o = Batoms('h2o', from_ase=molecule('H2O'))
-    co = Batoms('co', from_ase=molecule('CO'))
+    h2o = Batoms("h2o", from_ase=molecule("H2O"))
+    co = Batoms("co", from_ase=molecule("CO"))
     batoms = h2o + co
     assert len(batoms) == 5
     assert len(batoms.species) == 3
 
 
 def test_from_batoms():
-    """Load Batoms
-    """
+    """Load Batoms"""
     removeAll()
-    h2o = Batoms('h2o', from_ase=molecule('H2O'))
-    h2o = Batoms('h2o')
+    h2o = Batoms("h2o", from_ase=molecule("H2O"))
+    h2o = Batoms("h2o")
     assert isinstance(h2o, Batoms)
     assert len(h2o.species) == 2
     assert len(h2o) == 3
 
 
 def test_set_arrays():
-    """Set arrays and attributes
-    """
+    """Set arrays and attributes"""
     removeAll()
-    mol = molecule('H2O')
-    h2o = Batoms('h2o', from_ase=mol)
+    mol = molecule("H2O")
+    h2o = Batoms("h2o", from_ase=mol)
     h2o.show = [1, 0, 1]
     assert not h2o[1].show
     h2o.scale = [1, 1, 1]
-    h2o.set_attributes({'scale': np.array([0.3, 0.3, 0.3])})
+    h2o.set_attributes({"scale": np.array([0.3, 0.3, 0.3])})
     positions = h2o.positions
     assert len(positions) == 3
     del h2o[[2]]
-    assert len(h2o.arrays['positions']) == 2
+    assert len(h2o.arrays["positions"]) == 2
 
 
 def test_repeat():
-    """Repeat
-    """
+    """Repeat"""
     removeAll()
-    h2o = molecule('H2O')
-    h2o = Batoms(label='h2o', from_ase=h2o)
+    h2o = molecule("H2O")
+    h2o = Batoms(label="h2o", from_ase=h2o)
     h2o.cell = [3, 3, 3]
     h2o.pbc = True
     h2o.repeat([2, 2, 2])
@@ -219,10 +206,9 @@ def test_repeat():
 
 
 def test_get_geometry():
-    """Test geometry
-    """
+    """Test geometry"""
     removeAll()
-    h2o = Batoms('h2o', from_ase=molecule('H2O'))
+    h2o = Batoms("h2o", from_ase=molecule("H2O"))
     angle = h2o.get_angle(1, 0, 2)
     assert np.isclose(angle, 103.9998)
     d = h2o.get_distances(0, 1)
@@ -236,17 +222,18 @@ def test_get_geometry():
 def test_make_real():
     from ase.build import molecule
     from batoms.utils.butils import removeAll
+
     removeAll()
-    h2o = Batoms('h2o', from_ase=molecule('H2O'))
+    h2o = Batoms("h2o", from_ase=molecule("H2O"))
     h2o.make_real()
 
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     test_empty()
     test_batoms_molecule()
     test_batoms_crystal()
     test_batoms_species()
-    test_batoms_write('h2o.in')
+    test_batoms_write("h2o.in")
     test_batoms_transform()
     test_batoms_wrap()
     test_batoms_supercell()
@@ -259,4 +246,4 @@ if __name__ == '__main__':
     test_repeat()
     test_get_geometry()
     test_make_real()
-    print('\n Batoms: All pass! \n')
+    print("\n Batoms: All pass! \n")

--- a/test/test_boundary.py
+++ b/test/test_boundary.py
@@ -6,12 +6,12 @@ from batoms import Batoms
 
 def test_boundary():
     removeAll()
-    tio2 = read('datas/tio2.cif')
-    tio2 = Batoms('tio2', from_ase=tio2)
+    tio2 = read("datas/tio2.cif")
+    tio2 = Batoms("tio2", from_ase=tio2)
     tio2.boundary = 0.01
     assert len(tio2.boundary.obj.data.vertices) == 9
 
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     test_boundary()
-    print('\n Bondsetting: All pass! \n')
+    print("\n Bondsetting: All pass! \n")

--- a/test/test_camera.py
+++ b/test/test_camera.py
@@ -5,16 +5,24 @@ from batoms.utils.butils import removeAll
 from batoms.render import Camera
 from ase.build import fcc111
 
+try:
+    from _common_helpers import has_display, set_cycles_res
+
+    use_cycles = not has_display()
+except ImportError:
+    use_cycles = False
+
+extras = dict(engine="cycles") if use_cycles else {}
+
 
 def test_camera():
-    """
-    """
+    """ """
     removeAll()
-    camera = Camera(label='h2o', name='1')
+    camera = Camera(label="h2o", name="1")
     assert isinstance(camera, Camera)
     # properties
-    camera.type = 'PERSP'
-    assert camera.type == 'PERSP'
+    camera.type = "PERSP"
+    assert camera.type == "PERSP"
     camera.lens = 50
     assert camera.lens == 50
     camera.target = [5, 0, 0]
@@ -22,28 +30,32 @@ def test_camera():
 
 def test_camera_ortho():
     removeAll()
-    au111 = fcc111('Au', (4, 4, 4), vacuum=0)
-    au111 = Batoms('au111', from_ase=au111)
+    au111 = fcc111("Au", (4, 4, 4), vacuum=0)
+    au111 = Batoms("au111", from_ase=au111)
     au111.cell[2, 2] += 10
     # au111.draw_cell()
-    au111.get_image([1, 0, 0], output='camera_ortho.png')
-    #
-    au111.get_image([0, 0, 1], center=au111.positions[-1],
-                    output='camera-center.png')
+    if use_cycles:
+        set_cycles_res(au111)
+    au111.get_image([1, 0, 0], output="camera_ortho.png", **extras)
+    au111.get_image(
+        [0, 0, 1], center=au111.positions[-1], output="camera-center.png", **extras
+    )
 
 
 def test_camera_persp():
     removeAll()
-    au111 = fcc111('Au', (4, 10, 4), vacuum=0)
-    au111 = Batoms('au111', from_ase=au111)
+    au111 = fcc111("Au", (4, 10, 4), vacuum=0)
+    au111 = Batoms("au111", from_ase=au111)
     au111.cell[2, 2] += 10
     # au111.draw_cell()
-    au111.render.camera.type = 'PERSP'
-    au111.get_image([1, 0, 0], output='camera-persp.png')
+    au111.render.camera.type = "PERSP"
+    if use_cycles:
+        set_cycles_res(au111)
+    au111.get_image([1, 0, 0], output="camera-persp.png", **extras)
 
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     test_camera()
     test_camera_ortho()
     test_camera_persp()
-    print('\n camera: All pass! \n')
+    print("\n camera: All pass! \n")

--- a/test/test_cell.py
+++ b/test/test_cell.py
@@ -4,21 +4,19 @@ import numpy as np
 
 
 def test_cell():
-    """
-    """
-    cell = Bcell(label='pt', array=[2, 2, 2])
+    """ """
+    cell = Bcell(label="pt", array=[2, 2, 2])
     assert isinstance(cell, Bcell)
     cell[2, 2] += 5
     assert cell[2, 2] == 7
     cell.repeat([2, 2, 2])
-    assert np.allclose(cell.array, np.array(
-        [[4, 0, 0], [0, 4, 0], [0, 0, 14]]))
-    cell2 = cell.copy('pt-2')
+    assert np.allclose(cell.array, np.array([[4, 0, 0], [0, 4, 0], [0, 0, 14]]))
+    cell2 = cell.copy("pt-2")
     assert isinstance(cell2, Bcell)
     reciprocal = cell.reciprocal
     assert np.isclose(reciprocal[0, 0], 1.570796)
 
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     test_cell()
-    print('\n Cell: All pass! \n')
+    print("\n Cell: All pass! \n")

--- a/test/test_ci.sh
+++ b/test/test_ci.sh
@@ -1,0 +1,30 @@
+#!/bin/bash
+# Special settings for testing on CI systems, such as github actions.
+# Please run using
+# PYTHONPATH=$(pwd) bash test_ci.sh
+rm -rf *png
+if ! [ -z "$CI" ]
+then
+    echo "Running inside a CI system, use headleass only."
+    export DISPLAY=
+    export NOTEST_CUBE=1
+fi
+blender -b -P test_animation.py
+blender -b -P test_batom.py
+blender -b -P test_batoms.py
+blender -b -P test_boundary.py
+blender -b -P test_camera.py
+blender -b -P test_cell.py
+blender -b -P test_light.py
+# SAS systems need more attention
+# blender -b -P test_ms.py
+blender -b -P test_performance.py
+blender -b -P test_plane.py
+blender -b -P test_plugins.py
+blender -b -P test_polyhedrasetting.py
+blender -b -P test_real.py
+blender -b -P test_render.py
+blender -b -P test_ribbon.py
+blender -b -P test_select.py
+# skip the pytest if NOTEST_CUBE is set
+blender -b -P test_isosurfacesetting.py

--- a/test/test_isosurfacesetting.py
+++ b/test/test_isosurfacesetting.py
@@ -18,7 +18,6 @@ import os
 skip_test = bool(os.environ.get("NOTEST_CUBE", 0))
 
 
-
 def test_slice():
     if skip_test:
         pytest.skip("Skip tests on cube files since $NOTEST_CUBE provided.")

--- a/test/test_isosurfacesetting.py
+++ b/test/test_isosurfacesetting.py
@@ -5,39 +5,61 @@ from batoms.bio.bio import read
 import numpy as np
 from time import time
 
+try:
+    from _common_helpers import has_display, set_cycles_res
+
+    use_cycles = not has_display()
+except ImportError:
+    use_cycles = False
+
+extras = dict(engine="cycles") if use_cycles else {}
+import os
+
+skip_test = bool(os.environ.get("NOTEST_CUBE", 0))
+
+
 
 def test_slice():
+    if skip_test:
+        pytest.skip("Skip tests on cube files since $NOTEST_CUBE provided.")
     removeAll()
-    h2o = read('/home/xing/ase/batoms/h2o-homo.cube')
-    h2o.isosurfacesetting['1'] = {'level': -0.001}
-    h2o.isosurfacesetting['2'] = {'level': 0.001, 'color': [0, 0, 0.8, 0.5]}
+    h2o = read("/home/xing/ase/batoms/h2o-homo.cube")
+    h2o.isosurfacesetting["1"] = {"level": -0.001}
+    h2o.isosurfacesetting["2"] = {"level": 0.001, "color": [0, 0, 0.8, 0.5]}
     h2o.isosurfacesetting.draw_isosurface()
-    h2o.planesetting[(1, 0, 0)] = {'distance': 6, 'slicing': True}
+    h2o.planesetting[(1, 0, 0)] = {"distance": 6, "slicing": True}
     h2o.planesetting.draw_lattice_plane()
-    h2o.get_image([0, 0, 1], engine='eevee')
+    if use_cycles:
+        set_cycles_res(h2o)
+    h2o.get_image([0, 0, 1], **extras)
 
 
 def test_diff():
+    if skip_test:
+        pytest.skip("Skip tests on cube files since $NOTEST_CUBE provided.")
     removeAll()
-    ag_pto_fe = read('/home/xing/ase/batoms/ag-pto-fe.cube')
-    ag_pto = read('/home/xing/ase/batoms/ag-pto.cube')
+    ag_pto_fe = read("/home/xing/ase/batoms/ag-pto-fe.cube")
+    ag_pto = read("/home/xing/ase/batoms/ag-pto.cube")
     ag_pto.hide = True
-    fe = read('/home/xing/ase/batoms/fe.cube')
+    fe = read("/home/xing/ase/batoms/fe.cube")
     fe.hide = True
     volume = ag_pto_fe.volume - ag_pto.volume - fe.volume
     # volume = ag_pto_fe.isosurfacesetting.volume*2
     # print(volume)
     ag_pto_fe.volume = volume
     ag_pto_fe.isosurfacesetting[1].level = 0.008
-    ag_pto_fe.isosurfacesetting[2] = {'level': -0.008, 'color': [0, 0, 1, 0.8]}
+    ag_pto_fe.isosurfacesetting[2] = {"level": -0.008, "color": [0, 0, 1, 0.8]}
     ag_pto_fe.model_style = 1
     ag_pto_fe.isosurfacesetting.draw_isosurface()
-    ag_pto_fe.render.resolution = [3000, 3000]
-    ag_pto_fe.get_image([0, 0, 1], engine='eevee', output='top.png')
-    ag_pto_fe.get_image([1, 0, 0], engine='eevee', output='side.png')
+    if use_cycles:
+        set_cycles_res(ag_pto_fe)
+    else:
+        ag_pto_fe.render.resolution = [3000, 3000]
+    ag_pto_fe.get_image([0, 0, 1], output="top.png", **extras)
+    ag_pto_fe.get_image([1, 0, 0], output="side.png", **extras)
 
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     test_slice()
     test_diff()
-    print('\n Isosurfacesetting: All pass! \n')
+    print("\n Isosurfacesetting: All pass! \n")

--- a/test/test_light.py
+++ b/test/test_light.py
@@ -4,31 +4,42 @@ from batoms.utils.butils import removeAll
 from batoms.render import Render, Lights, Light
 from batoms.build import molecule
 
+try:
+    from _common_helpers import has_display, set_cycles_res
+
+    use_cycles = not has_display()
+except ImportError:
+    use_cycles = False
+
+extras = dict(engine="cycles") if use_cycles else {}
+
+
 def test_lights():
-    """
-    """
+    """ """
     removeAll()
-    r = Render(label = 'h2o')
+    r = Render(label="h2o")
     assert isinstance(r.lights, Lights)
     # properties
-    r.lights.add('1')
-    r.lights['1'].type = 'POINT'
-    assert r.lights['1'].type == 'POINT'
-    r.lights.add('2')
-    r.lights.remove('2')
+    r.lights.add("1")
+    r.lights["1"].type = "POINT"
+    assert r.lights["1"].type == "POINT"
+    r.lights.add("2")
+    r.lights.remove("2")
     assert len(r.lights) == 2
+
 
 def test_light_direction():
     removeAll()
-    h2o = molecule('h2o', 'H2O')
-    h2o.render.lights['Default'].type = 'POINT'
-    h2o.render.lights['Default'].energy = 1000
-    assert h2o.render.lights['Default'].type == 'POINT'
-    h2o.get_image([0, 0, 1], output='light-direction.png')    
+    h2o = molecule("h2o", "H2O")
+    h2o.render.lights["Default"].type = "POINT"
+    h2o.render.lights["Default"].energy = 1000
+    assert h2o.render.lights["Default"].type == "POINT"
+    if use_cycles:
+        set_cycles_res(h2o)
+    h2o.get_image([0, 0, 1], output="light-direction.png", **extras)
 
 
-
-if __name__ == '__main__':
+if __name__ == "__main__":
     test_lights()
     test_light_direction()
-    print('\n light: All pass! \n')
+    print("\n light: All pass! \n")

--- a/test/test_ms.py
+++ b/test/test_ms.py
@@ -13,8 +13,8 @@ def test_SAS():
     36.107
     """
     removeAll()
-    h2o = molecule('H2O')
-    h2o = Batoms('h2o', from_ase=h2o)
+    h2o = molecule("H2O")
+    h2o = Batoms("h2o", from_ase=h2o)
     h2o.mssetting.draw_SAS()
     # area = h2o.mssetting.get_psasa()
 
@@ -31,16 +31,17 @@ def test_SAS_protein():
     freesasa: 657.80
     """
     import numpy as np
+
     removeAll()
-    prot = read('datas/1ema.pdb')  # 1tim
-    prot = Batoms('1ema', from_ase=prot)
-    prot.mssetting['1'] = {'resolution': 0.4}
+    prot = read("datas/1ema.pdb")  # 1tim
+    prot = Batoms("1ema", from_ase=prot)
+    prot.mssetting["1"] = {"resolution": 0.4}
     prot.mssetting.draw_SAS()
-    area = prot.mssetting.get_sasa('1')
+    area = prot.mssetting.get_sasa("1")
     # area = prot.mssetting.get_psasa()
     assert abs(area[0] - 14461.704651512408) < 100
-    prot.selects.add('A', 'chain A')
-    prot.mssetting.add('2', {'select': 'A', 'color': [0.8, 0.1, 0.1, 1.0]})
+    prot.selects.add("A", "chain A")
+    prot.mssetting.add("2", {"select": "A", "color": [0.8, 0.1, 0.1, 1.0]})
     prot.mssetting.draw_SAS()
 
 
@@ -51,8 +52,8 @@ def test_SES():
     36.107
     """
     removeAll()
-    h2o = molecule('H2O')
-    h2o = Batoms('h2o', from_ase=h2o)
+    h2o = molecule("H2O")
+    h2o = Batoms("h2o", from_ase=h2o)
     h2o.mssetting.draw_SES()
     # area = h2o.mssetting.get_sasa(partial=True)[0]
 
@@ -76,8 +77,8 @@ def test_SES_protein():
     EDTSurf 7338 (Use slightly different vdw radii)
     """
     removeAll()
-    prot = read('/datas/1ema.pdb')
-    prot = Batoms('prot', from_ase=prot)
+    prot = read("/datas/1ema.pdb")
+    prot = Batoms("prot", from_ase=prot)
     tstart = time()
     prot.mssetting.draw_SES(parallel=2)
     t = time() - tstart
@@ -86,9 +87,9 @@ def test_SES_protein():
     assert abs(area - 20016.1) < 200
 
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     test_SAS()
     test_SAS_protein()
     test_SES()
     test_SES_protein()
-    print('\n MSsetting: All pass! \n')
+    print("\n MSsetting: All pass! \n")

--- a/test/test_performance.py
+++ b/test/test_performance.py
@@ -1,33 +1,34 @@
 import pytest
 from ase.build import bulk
 
+
 def test_position():
-    
+
     from batoms import Batoms
     from time import time
+
     tstart = time()
-    au = bulk('Au', cubic=True)
-    au = Batoms(label='au', from_ase=au, segments=[6, 6])
+    au = bulk("Au", cubic=True)
+    au = Batoms(label="au", from_ase=au, segments=[6, 6])
     au.repeat([10, 10, 20])
     au.repeat([5, 5, 5])
     t = time() - tstart
     assert t < 30
-    print('Repeat time: {:1.2f}'.format(t))
+    print("Repeat time: {:1.2f}".format(t))
     # get position
     tstart = time()
     positions = au.positions
     t = time() - tstart
     assert t < 4
-    print('Get positions time: {:1.2f}'.format(t))
+    print("Get positions time: {:1.2f}".format(t))
     # set position
     tstart = time()
-    au['Au'].positions = positions
+    au["Au"].positions = positions
     t = time() - tstart
     assert t < 4
-    print('Set positions time: {:1.2f}'.format(t))
+    print("Set positions time: {:1.2f}".format(t))
 
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     test_position()
-    print('\n Performance: All pass! \n')
-
+    print("\n Performance: All pass! \n")

--- a/test/test_plane.py
+++ b/test/test_plane.py
@@ -5,41 +5,45 @@ from batoms.utils.butils import removeAll
 from batoms.bio.bio import read
 import numpy as np
 
+skip_test = bool(os.environ.get("NOTEST_CUBE", 0))
+
+
 
 def test_lattice_plane():
     removeAll()
-    au = bulk('Au', cubic=True)
-    au = Batoms('au', from_ase=au)
-    au.planesetting[(1, 1, 1)] = {'distance': 3, 'scale': 1.1}
-    au.planesetting[(1, 1, 0)] = {'distance': 3, 'color': [0.8, 0.1, 0, 0.8]}
+    au = bulk("Au", cubic=True)
+    au = Batoms("au", from_ase=au)
+    au.planesetting[(1, 1, 1)] = {"distance": 3, "scale": 1.1}
+    au.planesetting[(1, 1, 0)] = {"distance": 3, "color": [0.8, 0.1, 0, 0.8]}
     au.planesetting.draw_lattice_plane()
     # au.draw_cell()
-    au.get_image([0, 0, 1], output='plane-lattice-plane.png')
+    au.get_image([0, 0, 1], output="plane-lattice-plane.png")
 
 
 def test_crystal_shape():
     removeAll()
-    au = bulk('Au', cubic=True)
-    au = Batoms('au', from_ase=au)
-    au.planesetting[(1, 1, 1)] = {'distance': 3,
-                                  'crystal': True,
-                                  'symmetry': True}
+    au = bulk("Au", cubic=True)
+    au = Batoms("au", from_ase=au)
+    au.planesetting[(1, 1, 1)] = {"distance": 3, "crystal": True, "symmetry": True}
     # au.planesetting[(0, 0, 1)] = {'distance': 3, 'crystal': True, 'symmetry': True}
     au.planesetting.draw_crystal_shape(origin=au.cell.center)
-    au.get_image([0, 0, 1], output='plane-crystal.png')
+    au.get_image([0, 0, 1], output="plane-crystal.png")
 
 
 def test_boundary():
+    # skip due to cubefile
+    if skip_test:
+        pytest.skip("Skip tests on cube files since $NOTEST_CUBE provided.")
     removeAll()
-    h2o = read('/home/xing/ase/batoms/h2o-homo.cube')
-    h2o.planesetting[(0, 0, 1)] = {'distance': 6, 'boundary': True}
-    h2o.planesetting[(0, 0, -1)] = {'distance': -5, 'boundary': True}
+    h2o = read("/home/xing/ase/batoms/h2o-homo.cube")
+    h2o.planesetting[(0, 0, 1)] = {"distance": 6, "boundary": True}
+    h2o.planesetting[(0, 0, -1)] = {"distance": -5, "boundary": True}
     h2o.planesetting.draw_lattice_plane()
-    h2o.get_image([1, 0, 0], output='plane-boundary.png')
+    h2o.get_image([1, 0, 0], output="plane-boundary.png")
 
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     test_lattice_plane()
     test_crystal_shape()
     test_boundary()
-    print('\n Bcell: All pass! \n')
+    print("\n Bcell: All pass! \n")

--- a/test/test_plane.py
+++ b/test/test_plane.py
@@ -4,9 +4,9 @@ from batoms import Batoms
 from batoms.utils.butils import removeAll
 from batoms.bio.bio import read
 import numpy as np
+import os
 
 skip_test = bool(os.environ.get("NOTEST_CUBE", 0))
-
 
 
 def test_lattice_plane():

--- a/test/test_plane.py
+++ b/test/test_plane.py
@@ -5,6 +5,14 @@ from batoms.utils.butils import removeAll
 from batoms.bio.bio import read
 import numpy as np
 import os
+try:
+    from _common_helpers import has_display, set_cycles_res
+
+    use_cycles = not has_display()
+except ImportError:
+    use_cycles = False
+
+extras = dict(engine="cycles") if use_cycles else {}
 
 skip_test = bool(os.environ.get("NOTEST_CUBE", 0))
 
@@ -17,7 +25,9 @@ def test_lattice_plane():
     au.planesetting[(1, 1, 0)] = {"distance": 3, "color": [0.8, 0.1, 0, 0.8]}
     au.planesetting.draw_lattice_plane()
     # au.draw_cell()
-    au.get_image([0, 0, 1], output="plane-lattice-plane.png")
+    if use_cycles:
+        set_cycles_res(au)
+    au.get_image([0, 0, 1], output="plane-lattice-plane.png", **extras)
 
 
 def test_crystal_shape():
@@ -27,7 +37,9 @@ def test_crystal_shape():
     au.planesetting[(1, 1, 1)] = {"distance": 3, "crystal": True, "symmetry": True}
     # au.planesetting[(0, 0, 1)] = {'distance': 3, 'crystal': True, 'symmetry': True}
     au.planesetting.draw_crystal_shape(origin=au.cell.center)
-    au.get_image([0, 0, 1], output="plane-crystal.png")
+    if use_cycles:
+        set_cycles_res(au)
+    au.get_image([0, 0, 1], output="plane-crystal.png", **extras)
 
 
 def test_boundary():
@@ -39,7 +51,9 @@ def test_boundary():
     h2o.planesetting[(0, 0, 1)] = {"distance": 6, "boundary": True}
     h2o.planesetting[(0, 0, -1)] = {"distance": -5, "boundary": True}
     h2o.planesetting.draw_lattice_plane()
-    h2o.get_image([1, 0, 0], output="plane-boundary.png")
+    if use_cycles:
+        set_cycles_res(h2o)
+    h2o.get_image([1, 0, 0], output="plane-boundary.png", **extras)
 
 
 if __name__ == "__main__":

--- a/test/test_plugins.py
+++ b/test/test_plugins.py
@@ -1,4 +1,3 @@
-
 from batoms import Batoms
 from batoms.plugins.pymatgen import pymatgen_search
 from pymatgen.core.structure import Molecule
@@ -13,6 +12,7 @@ def test_plugins_materials_project():
 
 def test_plugins_pubchem():
     from batoms.plugins.pubchem import pubchem_search
+
     removeAll()
     bas = pubchem_search("31423")
 
@@ -21,15 +21,15 @@ def test_plugins_pymatgen():
     removeAll()
     # molecule
     co = Molecule(["C", "O"], [[0.0, 0.0, 0.0], [0.0, 0.0, 1.2]])
-    co = Batoms(label='co', from_pymatgen=co)
+    co = Batoms(label="co", from_pymatgen=co)
     # lattice
-    fe = Structure(Lattice.cubic(2.8), ["Fe", "Fe"], [
-                   [0, 0, 0], [0.5, 0.5, 0.5]])
-    fe = Batoms(label='fe', from_pymatgen=fe)
+    fe = Structure(Lattice.cubic(2.8), ["Fe", "Fe"], [[0, 0, 0], [0.5, 0.5, 0.5]])
+    fe = Batoms(label="fe", from_pymatgen=fe)
     assert fe.pbc == [True, True, True]
 
-if __name__ == '__main__':
+
+if __name__ == "__main__":
     test_plugins_materials_project()
     test_plugins_pubchem()
     test_plugins_pymatgen()
-    print('\n Plugins: All pass! \n')
+    print("\n Plugins: All pass! \n")

--- a/test/test_polyhedrasetting.py
+++ b/test/test_polyhedrasetting.py
@@ -8,49 +8,49 @@ import numpy as np
 
 def test_polyhedra_molecule():
     removeAll()
-    ch4 = molecule('CH4')
+    ch4 = molecule("CH4")
     mh4 = ch4.copy()
     mh4.translate([2, 2, 0])
-    mh4[0].symbol = 'N'
+    mh4[0].symbol = "N"
     ch4 = ch4 + mh4
-    ch4 = Batoms('ch4', from_ase=ch4)
+    ch4 = Batoms("ch4", from_ase=ch4)
     ch4.model_style = 2
-    ch4.bonds.setting[('C', 'H')].polyhedra = True
+    ch4.bonds.setting[("C", "H")].polyhedra = True
     ch4.model_style = 1
 
 
 def test_polyhedra_crystal():
     removeAll()
-    tio2 = read('datas/tio2.cif')
-    tio2 = Batoms('tio2', from_ase=tio2)
+    tio2 = read("datas/tio2.cif")
+    tio2 = Batoms("tio2", from_ase=tio2)
     tio2.model_style = 2
-    tio2 = tio2*[3, 3, 3]
+    tio2 = tio2 * [3, 3, 3]
     tio2.pbc = False
     tio2.model_style = 2
 
 
 def test_polyhedra_setting():
     removeAll()
-    ch4 = Batoms('ch4', from_ase=molecule('CH4'))
-    ch4.bonds.setting[('C', 'H')].polyhedra = True
+    ch4 = Batoms("ch4", from_ase=molecule("CH4"))
+    ch4.bonds.setting[("C", "H")].polyhedra = True
     ch4.model_style = 2
     ch4.pbc = True
     ch4.cell = [3, 3, 3]
-    ch4 = ch4*[2, 1, 1]
-    sel1 = ch4.selects.add('sel1', [0, 1, 2, 3, 4])
+    ch4 = ch4 * [2, 1, 1]
+    sel1 = ch4.selects.add("sel1", [0, 1, 2, 3, 4])
     sel1.model_style = 1
-    ch4.polyhedras.setting.remove('C')
+    ch4.polyhedras.setting.remove("C")
     assert len(ch4.polyhedras.setting) == 1
-    ch4.polyhedras.setting.add('C')
+    ch4.polyhedras.setting.add("C")
     assert len(ch4.polyhedras.setting) == 2
-    ch4.polyhedras.setting['C'] = {'color': [0.8, 0.1, 0.3, 0.3]}
+    ch4.polyhedras.setting["C"] = {"color": [0.8, 0.1, 0.3, 0.3]}
     ch4.model_style = 2
-    ch4.render.engine = 'workbench'
-    ch4.get_image([1, 1, 0], output='polyhedras.png')
+    ch4.render.engine = "workbench"
+    ch4.get_image([1, 1, 0], output="polyhedras.png")
 
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     test_polyhedra_molecule()
     test_polyhedra_crystal()
     test_polyhedra_setting()
-    print('\n Polyhedra: All pass! \n')
+    print("\n Polyhedra: All pass! \n")

--- a/test/test_real.py
+++ b/test/test_real.py
@@ -8,20 +8,19 @@ from ase.build import graphene_nanoribbon
 
 def test_force_field():
     removeAll()
-    gnr = graphene_nanoribbon(2, 2, type='armchair', saturated=True,
-                              vacuum=3.5)
+    gnr = graphene_nanoribbon(2, 2, type="armchair", saturated=True, vacuum=3.5)
     gnr.pbc = False
-    gnr = Batoms('gnr', from_ase=gnr)
+    gnr = Batoms("gnr", from_ase=gnr)
 
 
 def test_force_field_al():
     removeAll()
-    al = Batoms('al', from_ase=bulk('Al'))
-    al = al*[1, 20, 1]
+    al = Batoms("al", from_ase=bulk("Al"))
+    al = al * [1, 20, 1]
     al.pbc = False
 
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     test_force_field()
     test_force_field_al()
-    print('\n Bcell: All pass! \n')
+    print("\n Bcell: All pass! \n")

--- a/test/test_render.py
+++ b/test/test_render.py
@@ -8,22 +8,22 @@ from batoms.utils.butils import removeAll
 
 def test_render():
     removeAll()
-    render = Render('test')
+    render = Render("test")
     assert isinstance(render, Render)
-    render.studiolight = 'paint.sl'
+    render.studiolight = "paint.sl"
     render.viewport = [1, 0, 0]
     render.resolution = [1000, 1000]
     # from collection
-    render = Render('test')
+    render = Render("test")
     assert isinstance(render, Render)
-    assert render.studiolight == 'paint.sl'
+    assert render.studiolight == "paint.sl"
     assert render.resolution == [1000, 1000]
 
 
 def test_render_init():
     removeAll()
-    h2o = molecule('H2O')
-    h2o = Batoms('h2o', from_ase=h2o)
+    h2o = molecule("H2O")
+    h2o = Batoms("h2o", from_ase=h2o)
     h2o.render.init()
     h2o.render.viewport = [1, 0, 0]
     h2o.get_image()
@@ -31,31 +31,31 @@ def test_render_init():
 
 def test_render_setter():
     removeAll()
-    h2o = molecule('H2O')
-    h2o = Batoms('h2o', from_ase=h2o)
+    h2o = molecule("H2O")
+    h2o = Batoms("h2o", from_ase=h2o)
     h2o.render.init()
     h2o.render.viewport = [1, 0, 0]
-    nh3 = molecule('NH3')
-    nh3 = Batoms('nh3', from_ase=nh3)
+    nh3 = molecule("NH3")
+    nh3 = Batoms("nh3", from_ase=nh3)
     nh3.translate([3, 3, 0])
-    nh3.render = Render('nh3')
+    nh3.render = Render("nh3")
     nh3.render.viewport = [0, 1, 0]
-    nh3.render.lights.add('1', type='SUN', direction=[1, 0, 0])
-    nh3.get_image(output='render-setter.png')
+    nh3.render.lights.add("1", type="SUN", direction=[1, 0, 0])
+    nh3.get_image(output="render-setter.png")
 
 
 def test_render_au111():
     removeAll()
-    atoms = fcc111('Au', size=(4, 4, 4), vacuum=0)
-    au111 = Batoms(label='au111', from_ase=atoms)
+    atoms = fcc111("Au", size=(4, 4, 4), vacuum=0)
+    au111 = Batoms(label="au111", from_ase=atoms)
     au111.cell[2, 2] += 5
     au111.get_image()
-    au111.get_image([1, 1, 1], engine='eevee', output='au111-eevee.png')
-    au111.get_image([1, 1, 1], engine='cycles', output='au111-cycles.png')
+    au111.get_image([1, 1, 1], engine="eevee", output="au111-eevee.png")
+    au111.get_image([1, 1, 1], engine="cycles", output="au111-cycles.png")
 
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     test_render()
     test_render_setter()
     test_render_au111()
-    print('\n render: All pass! \n')
+    print("\n render: All pass! \n")

--- a/test/test_ribbon.py
+++ b/test/test_ribbon.py
@@ -6,14 +6,14 @@ from batoms.batoms import Batoms
 
 def test_ribbon():
     removeAll()
-    atoms = read_pdb('datas/1ema.pdb')  # 1ema, 1tim, 4hhb
-    protein = Batoms('protein', from_ase=atoms)
+    atoms = read_pdb("datas/1ema.pdb")  # 1ema, 1tim, 4hhb
+    protein = Batoms("protein", from_ase=atoms)
     protein.ribbon.draw()
-    sel1 = protein.selects.add('sel1', 'sheet A-160-A-170')
+    sel1 = protein.selects.add("sel1", "sheet A-160-A-170")
     sel1.show = True
     sel1.model_style = 1
 
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     test_ribbon()
-    print('\n Ribbon: All pass! \n')
+    print("\n Ribbon: All pass! \n")

--- a/test/test_select.py
+++ b/test/test_select.py
@@ -5,29 +5,32 @@ from batoms.batoms import Batoms
 import numpy as np
 from time import time
 
+
 def test_select():
     removeAll()
-    au111 = fcc111('Au', (4, 4, 4), vacuum = 0)
-    au111 = Batoms('au111', from_ase = au111)
-    mol = Batoms('mol', from_ase=molecule('CH3CH2OH'))
+    au111 = fcc111("Au", (4, 4, 4), vacuum=0)
+    au111 = Batoms("au111", from_ase=au111)
+    mol = Batoms("mol", from_ase=molecule("CH3CH2OH"))
     mol.translate([5, 5, 10])
     au111 = au111 + mol
     au111.cell[2, 2] += 10
     assert len(au111.selects) == 3
-    au111.selects['mol'].model_style = 1
+    au111.selects["mol"].model_style = 1
+
 
 def test_select_protein():
     from batoms.pdbparser import read_pdb
+
     removeAll()
-    atoms = read_pdb('datas/1ema.pdb')  # 1tim
-    batoms = Batoms('protein', from_ase=atoms)
+    atoms = read_pdb("datas/1ema.pdb")  # 1tim
+    batoms = Batoms("protein", from_ase=atoms)
     batoms.ribbon.draw()
-    sel1 = batoms.selects.add('sel1', np.where(batoms.arrays['types'] == 'HETATM')[0])
+    sel1 = batoms.selects.add("sel1", np.where(batoms.arrays["types"] == "HETATM")[0])
     sel1.show = 1
     sel1.model_style = 1
 
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     test_select()
     test_select_protein()
-    print('\n Select: All pass! \n')
+    print("\n Select: All pass! \n")


### PR DESCRIPTION
Continuation to #2 with unit tests.
Changes made to this PR:
1. Fix typo in workflow files so that they can be run automatically
2. Unit tests (see `test/test_ci.sh`) for both local plugin test and docker image
3. Fix user preference persistence in docker image
4. Allow test files to choose rendering in cycles or eevee depending whether `$DISPLAY` is set (default to disable eevee in CI systems)
5. status badge