### PR TITLE
fix language related error for Geometry Node

### DIFF
--- a/batoms/batoms.py
+++ b/batoms/batoms.py
@@ -243,8 +243,8 @@ class Batoms(BaseCollection, ObjectGN):
         modifier = self.obj.modifiers.new(name=name, type='NODES')
         modifier.node_group.name = name
         inputs = modifier.node_group.inputs
-        GroupInput = modifier.node_group.nodes.get('Group Input')
-        GroupOutput = modifier.node_group.nodes.get('Group Output')
+        GroupInput = modifier.node_group.nodes[0]
+        GroupOutput = modifier.node_group.nodes[1]
         # add new output sockets
         for att in default_GroupInput:
             GroupInput.outputs.new(type=att[1], name=att[0])
@@ -308,7 +308,7 @@ class Batoms(BaseCollection, ObjectGN):
                 Object to be instanced
         """
         gn = self.gnodes
-        GroupInput = gn.node_group.nodes.get('Group Input')
+        GroupInput = gn.node_group.nodes[0]
         JoinGeometry = get_nodes_by_name(gn.node_group.nodes,
                                          '%s_JoinGeometry' % self.label,
                                          'GeometryNodeJoinGeometry')

--- a/batoms/bond/__init__.py
+++ b/batoms/bond/__init__.py
@@ -186,8 +186,8 @@ class Bonds(ObjectGN):
         modifier.node_group.name = name
         # ------------------------------------------------------------------
         inputs = modifier.node_group.inputs
-        GroupInput = modifier.node_group.nodes.get('Group Input')
-        GroupOutput = modifier.node_group.nodes.get('Group Output')
+        GroupInput = modifier.node_group.nodes[0]
+        GroupOutput = modifier.node_group.nodes[1]
         # add new output sockets
         for att in default_GroupInput:
             GroupInput.outputs.new(type=att[1], name=att[0])
@@ -416,7 +416,7 @@ class Bonds(ObjectGN):
         from batoms.utils.butils import get_nodes_by_name
         # tstart = time()
         gn = self.gnodes
-        GroupInput = gn.node_group.nodes.get('Group Input')
+        GroupInput = gn.node_group.nodes[0]
         SetPosition = get_nodes_by_name(gn.node_group.nodes,
                                         '%s_SetPosition' % self.label)
         JoinGeometry = get_nodes_by_name(gn.node_group.nodes,

--- a/batoms/boundary.py
+++ b/batoms/boundary.py
@@ -224,8 +224,8 @@ class Boundary(ObjectGN):
         modifier.node_group.name = name
         # ------------------------------------------------------------------
         inputs = modifier.node_group.inputs
-        GroupInput = modifier.node_group.nodes.get('Group Input')
-        GroupOutput = modifier.node_group.nodes.get('Group Output')
+        GroupInput = modifier.node_group.nodes[0]
+        GroupOutput = modifier.node_group.nodes[1]
         # add new output sockets
         for att in default_GroupInput:
             GroupInput.outputs.new(type=att[1], name=att[0])
@@ -235,7 +235,6 @@ class Boundary(ObjectGN):
             modifier['%s_attribute_name' % id] = att[0]
         gn = modifier
         # ------------------------------------------------------------------
-        GroupOutput = gn.node_group.nodes.get('Group Output')
         JoinGeometry = get_nodes_by_name(gn.node_group.nodes,
                                          '%s_JoinGeometry' % self.label,
                                          'GeometryNodeJoinGeometry')
@@ -308,7 +307,7 @@ class Boundary(ObjectGN):
         """
         from batoms.utils.butils import get_nodes_by_name
         gn = self.gnodes
-        GroupInput = gn.node_group.nodes.get('Group Input')
+        GroupInput = gn.node_group.nodes[0]
         SetPosition = get_nodes_by_name(gn.node_group.nodes,
                                         '%s_SetPosition' % self.label)
         JoinGeometry = get_nodes_by_name(gn.node_group.nodes,

--- a/batoms/cell.py
+++ b/batoms/cell.py
@@ -82,8 +82,8 @@ class Bcell(ObjectGN):
         # ------------------------------------------------------------------
         # select attributes
         gn = modifier
-        GroupInput = modifier.node_group.nodes.get('Group Input')
-        GroupOutput = gn.node_group.nodes.get('Group Output')
+        GroupInput = modifier.node_group.nodes[0]
+        GroupOutput = gn.node_group.nodes[1]
         JoinGeometry = get_nodes_by_name(gn.node_group.nodes,
                                          '%s_JoinGeometry' % self.label,
                                          'GeometryNodeJoinGeometry')

--- a/batoms/polyhedra/__init__.py
+++ b/batoms/polyhedra/__init__.py
@@ -177,8 +177,8 @@ class Polyhedras(ObjectGN):
         modifier.node_group.name = name
         # ------------------------------------------------------------------
         inputs = modifier.node_group.inputs
-        GroupInput = modifier.node_group.nodes.get('Group Input')
-        GroupOutput = modifier.node_group.nodes.get('Group Output')
+        GroupInput = modifier.node_group.nodes[0]
+        GroupOutput = modifier.node_group.nodes[1]
         # add new output sockets
         for att in default_GroupInput:
             GroupInput.outputs.new(type=att[1], name=att[0])
@@ -188,7 +188,6 @@ class Polyhedras(ObjectGN):
             modifier['%s_attribute_name' % id] = att[0]
         gn = modifier
         # ------------------------------------------------------------------
-        GroupOutput = gn.node_group.nodes.get('Group Output')
         # ------------------------------------------------------------------
         # calculate bond vector, length, rotation based on the index
         # Get four positions from batoms, bond and the second bond
@@ -259,8 +258,8 @@ class Polyhedras(ObjectGN):
     def add_geometry_node(self, sp):
         from batoms.utils.butils import get_nodes_by_name
         gn = self.gnodes
-        GroupInput = gn.node_group.nodes.get('Group Input')
-        GroupOutput = gn.node_group.nodes.get('Group Output')
+        GroupInput = gn.node_group.nodes[0]
+        GroupOutput = gn.node_group.nodes[1]
         previousNode = GroupOutput.inputs['Geometry'].links[0].from_socket
         # print(previousNode)
         # we need two compares for one species,

--- a/batoms/search_bond.py
+++ b/batoms/search_bond.py
@@ -128,8 +128,8 @@ class SearchBond(ObjectGN):
         modifier.node_group.name = name
         # ------------------------------------------------------------------
         inputs = modifier.node_group.inputs
-        GroupInput = modifier.node_group.nodes.get('Group Input')
-        GroupOutput = modifier.node_group.nodes.get('Group Output')
+        GroupInput = modifier.node_group.nodes[0]
+        GroupOutput = modifier.node_group.nodes[1]
         # add new output sockets
         for att in default_GroupInput:
             GroupInput.outputs.new(type=att[1], name=att[0])
@@ -139,7 +139,6 @@ class SearchBond(ObjectGN):
             modifier['%s_attribute_name' % id] = att[0]
         gn = modifier
         # ------------------------------------------------------------------
-        GroupOutput = gn.node_group.nodes.get('Group Output')
         JoinGeometry = get_nodes_by_name(gn.node_group.nodes,
                                          '%s_JoinGeometry' % self.label,
                                          'GeometryNodeJoinGeometry')
@@ -212,7 +211,7 @@ class SearchBond(ObjectGN):
         """
         from batoms.utils.butils import get_nodes_by_name
         gn = self.gnodes
-        GroupInput = gn.node_group.nodes.get('Group Input')
+        GroupInput = gn.node_group.nodes[0]
         SetPosition = get_nodes_by_name(gn.node_group.nodes,
                                         '%s_SetPosition' % self.label)
         JoinGeometry = get_nodes_by_name(gn.node_group.nodes,


### PR DESCRIPTION
Fix bug #20 
The name of the ``Group Input`` and ``Group output`` nodes of Geometry Node are language-related.
Use the index to get those nodes instead of the name.
``` python
GroupInput = modifier.node_group.nodes[0]
```