### PR TITLE
Shape keys

### DIFF
--- a/batoms/bond/__init__.py
+++ b/batoms/bond/__init__.py
@@ -767,6 +767,8 @@ class Bonds(BaseCollection, ObjectGN):
         if len(offsets[0]) != n:
             raise ValueError('offsets has wrong shape %s != %s.' %
                              (len(offsets[0]), n))
+        if n == 0:
+            return
         for i in range(4):
             vertices = offsets[i].reshape((n*3, 1))
             objs[i].data.vertices.foreach_set('co', vertices)
@@ -974,7 +976,7 @@ class Bonds(BaseCollection, ObjectGN):
 
         """
         from batoms.neighborlist import bondlist_kdtree
-        bondlists = np.zeros((0, 10), dtype=int)
+        bondlists = np.zeros((0, 11), dtype=int)
         bonddatas = {}
         if len(setting) == 0:
             return bondlists, bonddatas, {}, {}

--- a/batoms/bond/search_bond.py
+++ b/batoms/bond/search_bond.py
@@ -369,7 +369,12 @@ class SearchBond(ObjectGN):
         if len(offsets) != n:
             raise ValueError('offsets has wrong shape %s != %s.' %
                              (len(offsets), n))
+        if n == 0:
+            return
         offsets = offsets.reshape((n*3, 1))
+        if self.obj_o.data.shape_keys is None and len(self) > 0:
+            base_name = "Basis_%s"%self.obj_o.name
+            self.obj_o.shape_key_add(name=base_name)
         self.obj_o.data.shape_keys.key_blocks[0].data.foreach_set(
             'co', offsets)
         self.obj_o.data.update()

--- a/batoms/boundary.py
+++ b/batoms/boundary.py
@@ -1,5 +1,7 @@
 """
 # TODO add locaiton in geometry node
+# TODO rearrange code to handle offsets for all bonds, boundary
+       search_bond and so on
 """
 from time import time
 
@@ -493,6 +495,8 @@ class Boundary(ObjectGN):
         """
         n = len(self)
         offsets = np.empty(n*3, dtype=int)
+        if n == 0:
+            return
         self.obj_o.data.shape_keys.key_blocks[0].data.foreach_get(
             'co', offsets)
         return offsets.reshape((n, 3))
@@ -510,7 +514,12 @@ class Boundary(ObjectGN):
         if len(offsets) != n:
             raise ValueError('offsets has wrong shape %s != %s.' %
                              (len(offsets), n))
+        if n == 0:
+            return
         offsets = offsets.reshape((n*3, 1))
+        if self.obj_o.data.shape_keys is None and len(self) > 0:
+            base_name = "Basis_%s"%self.obj_o.name
+            self.obj_o.shape_key_add(name=base_name)
         self.obj_o.data.shape_keys.key_blocks[0].data.foreach_set(
             'co', offsets)
         self.obj_o.data.update()

--- a/batoms/polyhedra/__init__.py
+++ b/batoms/polyhedra/__init__.py
@@ -476,6 +476,8 @@ class Polyhedras(ObjectGN):
         if len(offsets) != n:
             raise ValueError('offsets has wrong shape %s != %s.' %
                              (len(offsets), n))
+        if n == 0:
+            return
         offsets = offsets.reshape((n*3, 1))
         self.obj_o.data.shape_keys.key_blocks[0].data.foreach_set(
             'co', offsets)

--- a/batoms/render/render.py
+++ b/batoms/render/render.py
@@ -19,7 +19,7 @@ class Render(BaseCollection):
                  run_render=True,
                  resolution=[1000, 758],
                  transparent=True,
-                 compute_device_type='CUDA',
+                #  compute_device_type='CUDA',
                  studiolight='Default',
                  samples=64,
                  ):
@@ -45,7 +45,8 @@ class Render(BaseCollection):
         transparent: bool
         resolution: list of 2 ints
         compute_device_type: str
-            enum in ['CUDA', 'OPENGL']
+            enum in ['NONE', 'CUDA', 'OPENGL', 'METAL', 'OPTIX'], depending
+            on computer.
         studiolight: str
             enum in ['Default', 'basic.sl', 'outdoor.sl',
                     'paint.sl', 'rim.sl', 'studio.sl']
@@ -57,7 +58,7 @@ class Render(BaseCollection):
         BaseCollection.__init__(self, coll_name=self.coll_name)
         self.batoms = batoms
         self.camera_name = '%s_camera' % self.label
-        self.compute_device_type = compute_device_type
+        # self.compute_device_type = compute_device_type
         coll = bpy.data.collections.get(self.coll_name)
         # load from collection
         self.output = output
@@ -189,9 +190,17 @@ class Render(BaseCollection):
         self.coll.batoms.brender.gpu = gpu
         if gpu:
             self.scene.cycles.device = 'GPU'
-            bpy.context.preferences.addons["cycles"].preferences.get_devices()
-            for device in bpy.context.preferences.addons["cycles"].preferences.devices:
+            # bpy.context.preferences.addons["cycles"].preferences.get_devices()
+            cprefs = bpy.context.preferences.addons["cycles"].preferences
+            for device in cprefs.devices:
                 device["use"] = 1  # Using all devices, include GPU and CPU
+            # auto set compute_device_type, depend on the computer
+            for compute_device_type in ('METAL', 'CUDA', 'OPENCL', 'NONE'):
+                try:
+                    cprefs.compute_device_type = compute_device_type
+                    break
+                except TypeError:
+                    pass
 
     @property
     def run_render(self):

--- a/tests/test_batoms.py
+++ b/tests/test_batoms.py
@@ -22,6 +22,7 @@ else:
 )
 def test_empty():
     """Create an empty Batoms object"""
+    from batoms import Batoms
     bpy.ops.batoms.delete()
     h2o = Batoms("h2o")
     assert len(h2o) == 0
@@ -30,6 +31,7 @@ def test_empty():
 def test_batoms_molecule():
     """Create a Batoms object from scratch"""
     bpy.ops.batoms.delete()
+    from batoms import Batoms
     h2o = Batoms(
         "h2o",
         species=["O", "H", "H"],

--- a/tests/test_bonds.py
+++ b/tests/test_bonds.py
@@ -17,6 +17,8 @@ extras = dict(engine="cycles") if use_cycles else {}
 
 def test_bonds():
     bpy.ops.batoms.delete()
+    from batoms.batoms import Batoms
+    from ase.build import molecule
     c2h6so = molecule("C2H6SO")
     c2h6so = Batoms("c2h6so", from_ase=c2h6so)
     c2h6so.model_style = 1

--- a/tests/test_render.py
+++ b/tests/test_render.py
@@ -29,6 +29,14 @@ def test_render():
     assert render.resolution == [200, 200]
 
 
+def test_render_gpu():
+    bpy.ops.batoms.delete()
+    h2o = molecule("H2O")
+    h2o = Batoms("h2o", from_ase=h2o)
+    h2o.render.init()
+    h2o.render.gpu = True
+
+
 def test_render_init():
     bpy.ops.batoms.delete()
     h2o = molecule("H2O")


### PR DESCRIPTION

In Blender 3.1, there is a warning when shape key is added to an empty mesh.  This issue makes blender unstable and crash randomly.

```
test_batoms.py::test_export_mesh_x3d WARN (bmesh.mesh.convert): 
source/blender/bmesh/intern/bmesh_mesh_convert.cc:862 bm_to_mesh_shape: Found shape-key but no CD_SHAPEKEY 
layers to read from, using basis shape-key data
```

This PR fixes the issue by checking whether the mesh is empty or not.